### PR TITLE
Add methods `CsrfMiddleware::getParameterName()` and `CsrfMiddleware::getHeaderName()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Yii CSRF Protection Library Change Log
 
-
 ## 1.0.4 under development
 
-- no changes in this release.
+- New #29: Add methods `CsrfMiddleware::getParameterName()` and `CsrfMiddleware::getHeaderName()` (vjik)
 
 ## 1.0.3 August 30, 2021
 

--- a/src/CsrfMiddleware.php
+++ b/src/CsrfMiddleware.php
@@ -64,6 +64,16 @@ final class CsrfMiddleware implements MiddlewareInterface
         return $new;
     }
 
+    public function getParameterName(): string
+    {
+        return $this->parameterName;
+    }
+
+    public function getHeaderName(): string
+    {
+        return $this->headerName;
+    }
+
     private function validateCsrfToken(ServerRequestInterface $request): bool
     {
         if (in_array($request->getMethod(), [Method::GET, Method::HEAD, Method::OPTIONS], true)) {

--- a/tests/CsrfMiddlewareTest.php
+++ b/tests/CsrfMiddlewareTest.php
@@ -13,17 +13,45 @@ use Yiisoft\Csrf\Tests\Synchronizer\Storage\MockCsrfTokenStorage;
 
 final class CsrfMiddlewareTest extends TestCase
 {
+    public function testDefaultParameterName(): void
+    {
+        $middleware = $this->createMiddleware();
+        $this->assertSame(CsrfMiddleware::PARAMETER_NAME, $middleware->getParameterName());
+    }
+
+    public function testGetParameterName(): void
+    {
+        $middleware = $this->createMiddleware()->withParameterName('my-csrf');
+        $this->assertSame('my-csrf', $middleware->getParameterName());
+    }
+
+    public function testDefaultHeaderName(): void
+    {
+        $middleware = $this->createMiddleware();
+        $this->assertSame(CsrfMiddleware::HEADER_NAME, $middleware->getHeaderName());
+    }
+
+    public function testGetHeaderName(): void
+    {
+        $middleware = $this->createMiddleware()->withHeaderName('MY-CSRF');
+        $this->assertSame('MY-CSRF', $middleware->getHeaderName());
+    }
+
     public function testImmutability(): void
     {
-        $original = new CsrfMiddleware(
+        $original = $this->createMiddleware();
+        $this->assertNotSame($original, $original->withHeaderName('csrf'));
+        $this->assertNotSame($original, $original->withParameterName('csrf'));
+    }
+
+    private function createMiddleware(): CsrfMiddleware
+    {
+        return new CsrfMiddleware(
             new Psr17Factory(),
             new SynchronizerCsrfToken(
                 new RandomCsrfTokenGenerator(),
                 new MockCsrfTokenStorage()
             )
         );
-
-        $this->assertNotSame($original, $original->withHeaderName('csrf'));
-        $this->assertNotSame($original, $original->withParameterName('csrf'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
