### PR TITLE
Add a custom failure handler feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0 under development
 
-- Enh #30: Add a custom failure handler feature to `CsrfMiddleware` (solventt)
+- Enh #30: Add a custom failure handler feature to `CsrfMiddleware` (solventt, devanych)
 - Chg #31: Update `yiisoft/http` dependency (devanych)
 
 ## 1.1.0 October 21, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Yii CSRF Protection Library Change Log
 
+## 1.2.0 under development
 
-## 1.1.1 under development
-
-- no changes in this release.
+- Enh #30: Add a custom failure handler feature to `CsrfMiddleware` (solventt)
 
 ## 1.1.0 October 21, 2021
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ return [
                     ->withMiddlewares(
                         [
                             ErrorCatcher::class,
-                            SessionMiddleware::class, // <-- add this
-                            CsrfMiddleware::class,
+                            SessionMiddleware::class,
+                            CsrfMiddleware::class, // <-- add this
                             Router::class,
                         ]
                     );
@@ -64,13 +64,47 @@ By default, CSRF token is obtained from `_csrf` request body parameter or `X-CSR
 You can access currently valid token as a string using `CsrfTokenInterface`:
 
 ```php
-/** @var \Yiisoft\Csrf\CsrfTokenInterface $csrfToken */
+/** @var Yiisoft\Csrf\CsrfTokenInterface $csrfToken */
 $csrf = $csrfToken->getValue();
+```
+
+If the token does not pass validation, the response `422 Unprocessable Entity` will be returned.
+You can change this behavior by implementing your own request handler:
+
+```php
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Csrf\CsrfMiddleware;
+
+/**
+ * @var Psr\Http\Message\ResponseFactoryInterface $responseFactory
+ * @var Yiisoft\Csrf\CsrfTokenInterface $csrfToken
+ */
+ 
+$failureHandler = new class ($responseFactory) implements RequestHandlerInterface {
+    private ResponseFactoryInterface $responseFactory;
+    
+    public function __construct(ResponseFactoryInterface $responseFactory)
+    {
+        $this->responseFactory = $responseFactory;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = new Response(400);
+        $response->getBody()->write('Bad request.');
+        return $response;
+    }
+};
+
+$middleware = new CsrfMiddleware($responseFactory, $csrfToken, $failureHandler);
 ```
 
 ## CSRF Tokens
 
-In case Yii framework is used along with config plugin, the package is [configured](./config/web.php) automatically to use synchronizer token and masked decorator. You can change that depending on your needs.
+In case Yii framework is used along with config plugin, the package is [configured](./config/web.php)
+automatically to use synchronizer token and masked decorator. You can change that depending on your needs.
 
 ### Synchronizer CSRF token
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $failureHandler = new class ($responseFactory) implements RequestHandlerInterfac
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $response = new Response(400);
+        $response = $this->responseFactory->createResponse(400);
         $response->getBody()->write('Bad request.');
         return $response;
     }

--- a/src/CsrfMiddleware.php
+++ b/src/CsrfMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Csrf;
 
+use Closure;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,24 +31,37 @@ final class CsrfMiddleware implements MiddlewareInterface
 
     private ResponseFactoryInterface $responseFactory;
     private CsrfTokenInterface $token;
+    private ?Closure $failureHandler;
 
     public function __construct(
         ResponseFactoryInterface $responseFactory,
-        CsrfTokenInterface $token
+        CsrfTokenInterface $token,
+        ?Closure $failureHandler = null
     ) {
         $this->responseFactory = $responseFactory;
         $this->token = $token;
+        $this->failureHandler = $failureHandler;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (!$this->validateCsrfToken($request)) {
+            return $this->handleFailure();
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function handleFailure(): ResponseInterface
+    {
+        if (is_null($handler = $this->failureHandler)) {
             $response = $this->responseFactory->createResponse(Status::UNPROCESSABLE_ENTITY);
             $response->getBody()->write(Status::TEXTS[Status::UNPROCESSABLE_ENTITY]);
             return $response;
         }
 
-        return $handler->handle($request);
+        /** @var Closure():ResponseInterface $handler */
+        return $handler();
     }
 
     public function withParameterName(string $name): self

--- a/tests/TokenCsrfMiddlewareTest.php
+++ b/tests/TokenCsrfMiddlewareTest.php
@@ -101,7 +101,7 @@ abstract class TokenCsrfMiddlewareTest extends TestCase
 
     public function testInvalidTokenResultWithCustomFailureHandler(): void
     {
-        $failureHandler = new class() implements RequestHandlerInterface {
+        $failureHandler = new class () implements RequestHandlerInterface {
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 $response = new Response(Status::BAD_REQUEST);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

I think it would be nice to let users define their custom failure handler. When a CSRF check fails one may want to do something else besides forming a simple Response, for example, destroy a session, log a CSRF "accident".

But this feature is good if this component is used separately outside of the yii framework. If you take the framework, you have to somehow inject a session and logger instances into the middleware.