### PR TITLE
Fix HMAC CSRF token payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.2.4 under development
 
+- Bug #32: Stop exposing CSRF HMAC token identity in token payload and update OWASP documentation link (@samdark)
 - Enh #82: Explicitly import classes and functions in "use" section (@mspirkov)
 - Enh #83: Remove unnecessary files from Composer package (@mspirkov)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.4 under development
 
-- Bug #32: Stop exposing CSRF HMAC token identity in token payload and update OWASP documentation link (@samdark)
+- Bug #32: Stop exposing CSRF HMAC token identity in token payload (@samdark)
 - Enh #82: Explicitly import classes and functions in "use" section (@mspirkov)
 - Enh #83: Remove unnecessary files from Composer package (@mspirkov)
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ flowchart TD
     C -- No --> S
     C -- Yes --> D{Token replay within lifetime OK?}
     D -- No --> S
-    D -- Yes --> H[HMAC]
+    D -- Yes --> H[HMAC signed]
 ```
 
 Detailed comparison:
@@ -208,9 +208,8 @@ To learn more about the synchronizer token pattern,
 ### HMAC signed token
 
 HMAC signed token is a stateless CSRF token that does not require any storage. The token contains expiration timestamp
-and random value, and its signature is bound to the current session ID. The token is added to a form. When the form is
-submitted, we verify the token signature, check that it belongs to the current session ID, and check that it has not
-expired.
+and its signature is bound to the current identity. The token is added to a form. When the form is submitted, we verify
+the token signature, check that it belongs to the current identity, and check that it has not expired.
 
 `HmacCsrfToken` requires implementation of `CsrfTokenIdentityGeneratorInterface` for generating an identity.
 The package provides `SessionCsrfTokenIdentityGenerator` that is using session ID thus making the session a token scope.

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ return [
 In case Yii framework is used along with config plugin, the package is [configured](./config/di-web.php)
 automatically to use synchronizer token and masked decorator. You can change that depending on your needs.
 
-Use synchronizer token for sensitive anonymous forms; use HMAC token for authenticated-only forms when a submitted
-token may stay valid for a few minutes.
+Use synchronizer token for sensitive anonymous forms; use HMAC token for authenticated-only forms when it is acceptable
+for a submitted token to stay valid until it expires.
 
 ```mermaid
 flowchart TD
@@ -168,7 +168,7 @@ Detailed comparison:
 | File based session GC | May scan session files | Not triggered by CSRF token storage |
 | Token storage growth | Depends on session storage | Nothing to store |
 | Token revocation | Possible by removing stored token | Not possible before token expiration |
-| Replay within lifetime | Prevented by storage policy | Possible until the token expires |
+| Replay within lifetime | Prevented by storage policy | Possible until expiration |
 
 To switch token to HMAC:
 
@@ -205,12 +205,12 @@ Package provides `RandomCsrfTokenGenerator` that generates a random token and
 To learn more about the synchronizer token pattern,
 [check OWASP CSRF cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern).
 
-### HMAC based token
+### HMAC signed token
 
-HMAC based token is a stateless CSRF token that does not require any storage. The token is a hash from session ID and
-a timestamp used to prevent replay attacks. The token is added to a form. When the form is submitted, we re-generate
-the token from the current session ID and a timestamp from the original token. If two hashes match, we check that the
-timestamp is less than the token lifetime.
+HMAC signed token is a stateless CSRF token that does not require any storage. The token contains expiration timestamp
+and random value, and its signature is bound to the current session ID. The token is added to a form. When the form is
+submitted, we verify the token signature, check that it belongs to the current session ID, and check that it has not
+expired.
 
 `HmacCsrfToken` requires implementation of `CsrfTokenIdentityGeneratorInterface` for generating an identity.
 The package provides `SessionCsrfTokenIdentityGenerator` that is using session ID thus making the session a token scope.
@@ -235,8 +235,8 @@ return [
 ];
 ```
 
-To learn more about HMAC based token pattern
-[check OWASP CSRF cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#hmac-based-token-pattern).
+To learn more about employing HMAC CSRF tokens, check the
+[OWASP CSRF cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-hmac-csrf-tokens).
 
 ### Stub CSRF token
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ return [
 In case Yii framework is used along with config plugin, the package is [configured](./config/di-web.php)
 automatically to use synchronizer token and masked decorator. You can change that depending on your needs.
 
-Use synchronizer token for sensitive anonymous forms; use HMAC token for authenticated-only forms when it is acceptable
-for a submitted token to stay valid until it expires.
+Use synchronizer token for sensitive anonymous forms; use HMAC signed token for authenticated-only forms when it is
+acceptable for a submitted token to stay valid until it expires.
 
 ```mermaid
 flowchart TD
@@ -162,7 +162,7 @@ flowchart TD
 
 Detailed comparison:
 
-| Factor | Synchronizer | HMAC |
+| Factor | Synchronizer | HMAC signed |
 |--------|--------------|------|
 | I/O per request | Session read and write | No token storage I/O |
 | File based session GC | May scan session files | Not triggered by CSRF token storage |
@@ -170,7 +170,7 @@ Detailed comparison:
 | Token revocation | Possible by removing stored token | Not possible before token expiration |
 | Replay within lifetime | Prevented by storage policy | Possible until expiration |
 
-To switch token to HMAC:
+To switch to HMAC signed token:
 
 ```php
 use Yiisoft\Csrf\CsrfTokenInterface;

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Csrf\Hmac;
 
+use InvalidArgumentException;
 use RuntimeException;
 use Yiisoft\Csrf\CsrfTokenInterface;
 use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
@@ -39,6 +40,11 @@ final class HmacCsrfToken implements CsrfTokenInterface
     private string $algorithm;
 
     /**
+     * @var int Hash length in bytes.
+     */
+    private int $hashLength;
+
+    /**
      * @var int|null Number of seconds that the token is valid for.
      */
     private ?int $lifetime;
@@ -52,6 +58,7 @@ final class HmacCsrfToken implements CsrfTokenInterface
         $this->identityGenerator = $identityGenerator;
         $this->secretKey = $secretKey;
         $this->algorithm = $algorithm;
+        $this->hashLength = $this->generateHashLength();
         $this->lifetime = $lifetime;
     }
 
@@ -71,9 +78,8 @@ final class HmacCsrfToken implements CsrfTokenInterface
 
         [$expiration, $payload] = $data;
 
-        $hashLength = $this->getHashLength();
-        $hash = StringHelper::byteSubstring($payload, 0, $hashLength);
-        $message = StringHelper::byteSubstring($payload, $hashLength, null);
+        $hash = StringHelper::byteSubstring($payload, 0, $this->hashLength);
+        $message = StringHelper::byteSubstring($payload, $this->hashLength, null);
 
         if (!hash_equals($hash, $this->generateHash($message))) {
             return false;
@@ -97,14 +103,17 @@ final class HmacCsrfToken implements CsrfTokenInterface
      */
     private function extractData(string $token): ?array
     {
-        $payload = StringHelper::base64UrlDecode($token);
-        $hashLength = $this->getHashLength();
-
-        if (StringHelper::byteLength($payload) <= $hashLength) {
+        try {
+            $payload = StringHelper::base64UrlDecode($token);
+        } catch (InvalidArgumentException $e) {
             return null;
         }
 
-        $message = StringHelper::byteSubstring($payload, $hashLength, null);
+        if (StringHelper::byteLength($payload) <= $this->hashLength) {
+            return null;
+        }
+
+        $message = StringHelper::byteSubstring($payload, $this->hashLength, null);
         $chunks = explode('~', $message, 2);
         if (count($chunks) !== 2) {
             return null;
@@ -133,8 +142,12 @@ final class HmacCsrfToken implements CsrfTokenInterface
         return $hash;
     }
 
-    private function getHashLength(): int
+    private function generateHashLength(): int
     {
-        return StringHelper::byteLength($this->generateHash(''));
+        $hash = hash_hmac($this->algorithm, '', '', true);
+        if (!$hash) {
+            throw new RuntimeException("Failed to generate HMAC with hash algorithm: {$this->algorithm}.");
+        }
+        return StringHelper::byteLength($hash);
     }
 }

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -93,7 +93,7 @@ final class HmacCsrfToken implements CsrfTokenInterface
 
     private function generateToken(?int $expiration): string
     {
-        $message = (string) $expiration . '~' . Random::string(32);
+        $message = ($expiration ?? '') . '~' . Random::string(32);
 
         return StringHelper::base64UrlEncode($this->generateHash($message) . $message);
     }
@@ -106,10 +106,6 @@ final class HmacCsrfToken implements CsrfTokenInterface
         try {
             $payload = StringHelper::base64UrlDecode($token);
         } catch (InvalidArgumentException $e) {
-            return null;
-        }
-
-        if (StringHelper::byteLength($payload) <= $this->hashLength) {
             return null;
         }
 

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Csrf\Hmac;
 
-use InvalidArgumentException;
 use Yiisoft\Csrf\CsrfTokenInterface;
 use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
 use Yiisoft\Csrf\MaskedCsrfToken;
@@ -65,9 +64,6 @@ final class HmacCsrfToken implements CsrfTokenInterface
     public function validate(string $token): bool
     {
         $raw = $this->decode($token);
-        if ($raw === null) {
-            return false;
-        }
 
         $message = $this->extractMessage($raw);
         if ($message === null) {
@@ -100,13 +96,9 @@ final class HmacCsrfToken implements CsrfTokenInterface
         );
     }
 
-    private function decode(string $token): ?string
+    private function decode(string $token): string
     {
-        try {
-            return StringHelper::base64UrlDecode($token);
-        } catch (InvalidArgumentException $e) {
-            return null;
-        }
+        return StringHelper::base64UrlDecode($token);
     }
 
     private function extractMessage(string $raw): ?string

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -4,36 +4,39 @@ declare(strict_types=1);
 
 namespace Yiisoft\Csrf\Hmac;
 
+use RuntimeException;
 use Yiisoft\Csrf\CsrfTokenInterface;
 use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
-use Yiisoft\Security\DataIsTamperedException;
-use Yiisoft\Security\Mac;
-use Yiisoft\Strings\StringHelper;
 use Yiisoft\Csrf\MaskedCsrfToken;
+use Yiisoft\Security\Random;
+use Yiisoft\Strings\StringHelper;
 
 use function count;
+use function hash_equals;
+use function hash_hmac;
 
 /**
- * Stateless CSRF token that does not require any storage. The token is a hash from session ID and a timestamp
- * (to prevent replay attacks). It is added to forms. When the form is submitted, we re-generate the token from
- * the current session ID and a timestamp from the original token. If two hashes match, we check that timestamp is
- * less than {@see HmacCsrfToken::$lifetime}.
- *
- * The algorithm is also known as "HMAC Based Token".
+ * Stateless CSRF token that does not require any storage. The token contains expiration timestamp and random value,
+ * and is signed with a session-bound identity. It is added to forms. When the form is submitted, we verify the token
+ * signature, check that it belongs to the current session identity, and check that it has not expired.
  *
  * Do not forget to decorate the token with {@see MaskedCsrfToken} to prevent BREACH attack.
  *
- * @link https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#hmac-based-token-pattern
+ * @link https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-hmac-csrf-tokens
  */
 final class HmacCsrfToken implements CsrfTokenInterface
 {
     private CsrfTokenIdentityGeneratorInterface $identityGenerator;
-    private Mac $mac;
 
     /**
      * @var string Shared secret key used to generate the hash.
      */
     private string $secretKey;
+
+    /**
+     * @var string Hash algorithm for message authentication.
+     */
+    private string $algorithm;
 
     /**
      * @var int|null Number of seconds that the token is valid for.
@@ -47,8 +50,8 @@ final class HmacCsrfToken implements CsrfTokenInterface
         ?int $lifetime = null
     ) {
         $this->identityGenerator = $identityGenerator;
-        $this->mac = new Mac($algorithm);
         $this->secretKey = $secretKey;
+        $this->algorithm = $algorithm;
         $this->lifetime = $lifetime;
     }
 
@@ -66,39 +69,43 @@ final class HmacCsrfToken implements CsrfTokenInterface
             return false;
         }
 
-        [$expiration, $identity] = $data;
+        [$expiration, $payload] = $data;
+
+        $hashLength = $this->getHashLength();
+        $hash = StringHelper::byteSubstring($payload, 0, $hashLength);
+        $message = StringHelper::byteSubstring($payload, $hashLength, null);
+
+        if (!hash_equals($hash, $this->generateHash($message))) {
+            return false;
+        }
 
         if ($expiration !== null && time() > $expiration) {
             return false;
         }
-
-        return $identity === $this->identityGenerator->generate();
+        return true;
     }
 
     private function generateToken(?int $expiration): string
     {
-        return StringHelper::base64UrlEncode(
-            $this->mac->sign(
-                (string) $expiration . '~' . $this->identityGenerator->generate(),
-                $this->secretKey,
-                true,
-            ),
-        );
+        $message = (string) $expiration . '~' . Random::string(32);
+
+        return StringHelper::base64UrlEncode($this->generateHash($message) . $message);
     }
 
+    /**
+     * @return array{0: int|null, 1: string}|null
+     */
     private function extractData(string $token): ?array
     {
-        try {
-            $raw = $this->mac->getMessage(
-                StringHelper::base64UrlDecode($token),
-                $this->secretKey,
-                true,
-            );
-        } catch (DataIsTamperedException $e) {
+        $payload = StringHelper::base64UrlDecode($token);
+        $hashLength = $this->getHashLength();
+
+        if (StringHelper::byteLength($payload) <= $hashLength) {
             return null;
         }
 
-        $chunks = explode('~', $raw, 2);
+        $message = StringHelper::byteSubstring($payload, $hashLength, null);
+        $chunks = explode('~', $message, 2);
         if (count($chunks) !== 2) {
             return null;
         }
@@ -112,8 +119,22 @@ final class HmacCsrfToken implements CsrfTokenInterface
             }
         }
 
-        $identity = $chunks[1];
+        return [$expiration, $payload];
+    }
 
-        return [$expiration, $identity];
+    private function generateHash(string $message): string
+    {
+        $identity = $this->identityGenerator->generate();
+        $message = StringHelper::byteLength($identity) . '~' . $identity . '~' . $message;
+        $hash = hash_hmac($this->algorithm, $message, $this->secretKey, true);
+        if (!$hash) {
+            throw new RuntimeException("Failed to generate HMAC with hash algorithm: {$this->algorithm}.");
+        }
+        return $hash;
+    }
+
+    private function getHashLength(): int
+    {
+        return StringHelper::byteLength($this->generateHash(''));
     }
 }

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -51,7 +51,7 @@ final class HmacCsrfToken implements CsrfTokenInterface
         CsrfTokenIdentityGeneratorInterface $identityGenerator,
         string $secretKey,
         string $algorithm = 'sha256',
-        ?int $lifetime = null,
+        ?int $lifetime = null
     ) {
         $this->identityGenerator = $identityGenerator;
         $this->secretKey = $secretKey;
@@ -129,12 +129,7 @@ final class HmacCsrfToken implements CsrfTokenInterface
     {
         $identity = $this->identityGenerator->generate();
         $message = StringHelper::byteLength($identity) . '~' . $identity . '~' . $message;
-        $hash = hash_hmac(
-            $this->algorithm,
-            $message,
-            $this->secretKey,
-            true,
-        );
+        $hash = hash_hmac($this->algorithm, $message, $this->secretKey, true);
         if (!$hash) {
             throw new RuntimeException("Failed to generate HMAC with hash algorithm: {$this->algorithm}.");
         }

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -9,17 +9,15 @@ use RuntimeException;
 use Yiisoft\Csrf\CsrfTokenInterface;
 use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
 use Yiisoft\Csrf\MaskedCsrfToken;
-use Yiisoft\Security\Random;
 use Yiisoft\Strings\StringHelper;
 
-use function count;
 use function hash_equals;
 use function hash_hmac;
 
 /**
- * Stateless CSRF token that does not require any storage. The token contains expiration timestamp and random value,
- * and is signed with a session-bound identity. It is added to forms. When the form is submitted, we verify the token
- * signature, check that it belongs to the current session identity, and check that it has not expired.
+ * Stateless CSRF token that does not require any storage. The token contains an expiration timestamp and is signed with
+ * an identity-bound key. It is added to forms. When the form is submitted, we verify the token signature, check that it
+ * belongs to the current identity, and check that it has not expired.
  *
  * Do not forget to decorate the token with {@see MaskedCsrfToken} to prevent BREACH attack.
  *
@@ -53,12 +51,12 @@ final class HmacCsrfToken implements CsrfTokenInterface
         CsrfTokenIdentityGeneratorInterface $identityGenerator,
         string $secretKey,
         string $algorithm = 'sha256',
-        ?int $lifetime = null
+        ?int $lifetime = null,
     ) {
         $this->identityGenerator = $identityGenerator;
         $this->secretKey = $secretKey;
         $this->algorithm = $algorithm;
-        $this->hashLength = $this->generateHashLength();
+        $this->hashLength = $this->calcHashLength();
         $this->lifetime = $lifetime;
     }
 
@@ -94,7 +92,7 @@ final class HmacCsrfToken implements CsrfTokenInterface
 
     private function generateToken(?int $expiration): string
     {
-        $message = ($expiration ?? '') . '~' . Random::string(32);
+        $message = (string) $expiration;
 
         return StringHelper::base64UrlEncode($this->generateHash($message) . $message);
     }
@@ -110,17 +108,16 @@ final class HmacCsrfToken implements CsrfTokenInterface
             return null;
         }
 
-        $message = StringHelper::byteSubstring($payload, $this->hashLength, null);
-        $chunks = explode('~', $message, 2);
-        if (count($chunks) !== 2) {
+        if (StringHelper::byteLength($payload) < $this->hashLength) {
             return null;
         }
 
-        if ($chunks[0] === '') {
+        $message = StringHelper::byteSubstring($payload, $this->hashLength, null);
+        if ($message === '') {
             $expiration = null;
         } else {
-            $expiration = (int) $chunks[0];
-            if ((string) $expiration !== $chunks[0]) {
+            $expiration = (int) $message;
+            if ((string) $expiration !== $message) {
                 return null;
             }
         }
@@ -132,14 +129,19 @@ final class HmacCsrfToken implements CsrfTokenInterface
     {
         $identity = $this->identityGenerator->generate();
         $message = StringHelper::byteLength($identity) . '~' . $identity . '~' . $message;
-        $hash = hash_hmac($this->algorithm, $message, $this->secretKey, true);
+        $hash = hash_hmac(
+            $this->algorithm,
+            $message,
+            $this->secretKey,
+            true,
+        );
         if (!$hash) {
             throw new RuntimeException("Failed to generate HMAC with hash algorithm: {$this->algorithm}.");
         }
         return $hash;
     }
 
-    private function generateHashLength(): int
+    private function calcHashLength(): int
     {
         $hash = hash_hmac($this->algorithm, '', '', true);
         if (!$hash) {

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Yiisoft\Csrf\Hmac;
 
 use InvalidArgumentException;
-use RuntimeException;
 use Yiisoft\Csrf\CsrfTokenInterface;
 use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
 use Yiisoft\Csrf\MaskedCsrfToken;
+use Yiisoft\Security\DataIsTamperedException;
+use Yiisoft\Security\Mac;
 use Yiisoft\Strings\StringHelper;
-
-use function hash_equals;
-use function hash_hmac;
 
 /**
  * Stateless CSRF token that does not require any storage. The token contains an expiration timestamp and is signed with
@@ -27,15 +25,12 @@ final class HmacCsrfToken implements CsrfTokenInterface
 {
     private CsrfTokenIdentityGeneratorInterface $identityGenerator;
 
-    /**
-     * @var string Shared secret key used to generate the hash.
-     */
-    private string $secretKey;
+    private Mac $mac;
 
     /**
-     * @var string Hash algorithm for message authentication.
+     * @var string Shared secret key used to sign the token.
      */
-    private string $algorithm;
+    private string $secretKey;
 
     /**
      * @var int Hash length in bytes.
@@ -54,8 +49,8 @@ final class HmacCsrfToken implements CsrfTokenInterface
         ?int $lifetime = null
     ) {
         $this->identityGenerator = $identityGenerator;
+        $this->mac = new Mac($algorithm);
         $this->secretKey = $secretKey;
-        $this->algorithm = $algorithm;
         $this->hashLength = $this->calcHashLength();
         $this->lifetime = $lifetime;
     }
@@ -69,79 +64,68 @@ final class HmacCsrfToken implements CsrfTokenInterface
 
     public function validate(string $token): bool
     {
-        $data = $this->extractData($token);
-        if ($data === null) {
+        $raw = $this->decode($token);
+        if ($raw === null) {
             return false;
         }
 
-        [$expiration, $payload] = $data;
-
-        if ($expiration !== null && time() > $expiration) {
+        $message = $this->extractMessage($raw);
+        if ($message === null) {
             return false;
         }
 
-        $hash = StringHelper::byteSubstring($payload, 0, $this->hashLength);
-        $message = StringHelper::byteSubstring($payload, $this->hashLength, null);
-
-        if (!hash_equals($hash, $this->generateHash($message))) {
-            return false;
+        if ($message !== '') {
+            $expiration = (int) $message;
+            if ((string) $expiration !== $message || time() > $expiration) {
+                return false;
+            }
         }
 
-        return true;
+        try {
+            $this->mac->getMessage($raw, $this->generateActualSecretKey(), true);
+            return true;
+        } catch (DataIsTamperedException $e) {
+            return false;
+        }
     }
 
     private function generateToken(?int $expiration): string
     {
-        $message = (string) $expiration;
-
-        return StringHelper::base64UrlEncode($this->generateHash($message) . $message);
+        return StringHelper::base64UrlEncode(
+            $this->mac->sign(
+                (string) $expiration,
+                $this->generateActualSecretKey(),
+                true,
+            ),
+        );
     }
 
-    /**
-     * @return array{0: int|null, 1: string}|null
-     */
-    private function extractData(string $token): ?array
+    private function decode(string $token): ?string
     {
         try {
-            $payload = StringHelper::base64UrlDecode($token);
+            return StringHelper::base64UrlDecode($token);
         } catch (InvalidArgumentException $e) {
             return null;
         }
+    }
 
-        if (StringHelper::byteLength($payload) < $this->hashLength) {
+    private function extractMessage(string $raw): ?string
+    {
+        if (StringHelper::byteLength($raw) < $this->hashLength) {
             return null;
         }
 
-        $message = StringHelper::byteSubstring($payload, $this->hashLength, null);
-        if ($message === '') {
-            $expiration = null;
-        } else {
-            $expiration = (int) $message;
-            if ((string) $expiration !== $message) {
-                return null;
-            }
-        }
-
-        return [$expiration, $payload];
+        return StringHelper::byteSubstring($raw, $this->hashLength, null);
     }
 
-    private function generateHash(string $message): string
+    private function generateActualSecretKey(): string
     {
         $identity = $this->identityGenerator->generate();
-        $message = StringHelper::byteLength($identity) . '~' . $identity . '~' . $message;
-        $hash = hash_hmac($this->algorithm, $message, $this->secretKey, true);
-        if (!$hash) {
-            throw new RuntimeException("Failed to generate HMAC with hash algorithm: {$this->algorithm}.");
-        }
-        return $hash;
+        return $this->secretKey . '~' . $identity;
     }
 
     private function calcHashLength(): int
     {
-        $hash = hash_hmac($this->algorithm, '', '', true);
-        if (!$hash) {
-            throw new RuntimeException("Failed to generate HMAC with hash algorithm: {$this->algorithm}.");
-        }
-        return StringHelper::byteLength($hash);
+        return StringHelper::byteLength($this->mac->sign('', '', true));
     }
 }

--- a/src/Hmac/HmacCsrfToken.php
+++ b/src/Hmac/HmacCsrfToken.php
@@ -78,6 +78,10 @@ final class HmacCsrfToken implements CsrfTokenInterface
 
         [$expiration, $payload] = $data;
 
+        if ($expiration !== null && time() > $expiration) {
+            return false;
+        }
+
         $hash = StringHelper::byteSubstring($payload, 0, $this->hashLength);
         $message = StringHelper::byteSubstring($payload, $this->hashLength, null);
 
@@ -85,9 +89,6 @@ final class HmacCsrfToken implements CsrfTokenInterface
             return false;
         }
 
-        if ($expiration !== null && time() > $expiration) {
-            return false;
-        }
         return true;
     }
 

--- a/tests/Hmac/HmacCsrfTokenTest.php
+++ b/tests/Hmac/HmacCsrfTokenTest.php
@@ -121,6 +121,18 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertTrue($csrfToken->validate($this->createToken('user7', '500')));
     }
 
+    public function testRejectsTokenSignedWithDifferentIdentity(): void
+    {
+        self::$timeResult = 300;
+
+        $csrfToken = new HmacCsrfToken(
+            new MockCsrfTokenIdentityGenerator('user7'),
+            'mySecretKey',
+        );
+
+        $this->assertFalse($csrfToken->validate($this->createToken('user8', '500')));
+    }
+
     public function testRejectsSignedTokenWithMalformedMessage(): void
     {
         self::$timeResult = 300;

--- a/tests/Hmac/HmacCsrfTokenTest.php
+++ b/tests/Hmac/HmacCsrfTokenTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Yiisoft\Csrf\Hmac\HmacCsrfToken;
 use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
 use Yiisoft\Csrf\Tests\Hmac\IdentityGenerator\MockCsrfTokenIdentityGenerator;
+use Yiisoft\Security\Mac;
 use Yiisoft\Security\Random;
 use Yiisoft\Strings\StringHelper;
 
@@ -184,18 +185,12 @@ final class HmacCsrfTokenTest extends TestCase
 
     private function createToken(string $identity, string $message): string
     {
-        $signedMessage = StringHelper::byteLength($identity) . '~' . $identity . '~' . $message;
-        $hash = hash_hmac('sha256', $signedMessage, 'mySecretKey', true);
-        if (!$hash) {
-            self::fail('Failed to generate HMAC.');
-        }
-
-        return StringHelper::base64UrlEncode($hash . $message);
+        return StringHelper::base64UrlEncode((new Mac())->sign($message, 'mySecretKey~' . $identity, true));
     }
 
     private function getHashLength(): int
     {
-        return StringHelper::byteLength(hash_hmac('sha256', '', '', true));
+        return StringHelper::byteLength((new Mac())->sign('', '', true));
     }
 }
 

--- a/tests/Hmac/HmacCsrfTokenTest.php
+++ b/tests/Hmac/HmacCsrfTokenTest.php
@@ -166,6 +166,25 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertSame(0, $identityGenerator->calls);
     }
 
+    public function testExpiredTokenDoesNotGenerateIdentity(): void
+    {
+        self::$timeResult = 300;
+
+        $identityGenerator = new class implements CsrfTokenIdentityGeneratorInterface {
+            public int $calls = 0;
+
+            public function generate(): string
+            {
+                $this->calls++;
+                return 'user7';
+            }
+        };
+        $csrfToken = new HmacCsrfToken($identityGenerator, 'mySecretKey');
+
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', '299~random-value')));
+        $this->assertSame(0, $identityGenerator->calls);
+    }
+
     public function testIdentityWithTilda(): void
     {
         $csrfToken = new HmacCsrfToken(

--- a/tests/Hmac/HmacCsrfTokenTest.php
+++ b/tests/Hmac/HmacCsrfTokenTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Yiisoft\Csrf\Hmac\HmacCsrfToken;
 use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
 use Yiisoft\Csrf\Tests\Hmac\IdentityGenerator\MockCsrfTokenIdentityGenerator;
-use Yiisoft\Security\Mac;
 use Yiisoft\Security\Random;
 use Yiisoft\Strings\StringHelper;
 
@@ -39,16 +38,6 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertTrue($csrfToken->validate($token));
     }
 
-    public function testTokenValueChanges(): void
-    {
-        $csrfToken = new HmacCsrfToken(
-            new MockCsrfTokenIdentityGenerator('user7'),
-            'mySecretKey',
-        );
-
-        $this->assertNotSame($csrfToken->getValue(), $csrfToken->getValue());
-    }
-
     public function testTokenDoesNotExposeIdentity(): void
     {
         $identity = 'session-id-that-must-not-be-in-token';
@@ -63,7 +52,7 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertTrue($csrfToken->validate($token));
     }
 
-    public function testTokenPayloadContainsExpirationAndRandomValue(): void
+    public function testTokenPayloadContainsExpiration(): void
     {
         self::$timeResult = 300;
 
@@ -77,7 +66,7 @@ final class HmacCsrfTokenTest extends TestCase
         $payload = StringHelper::base64UrlDecode($csrfToken->getValue());
         $message = StringHelper::byteSubstring($payload, $this->getHashLength(), null);
 
-        $this->assertMatchesRegularExpression('/^400~[A-Za-z0-9_-]{32}$/', $message);
+        $this->assertSame('400', $message);
     }
 
     public function testExpiration(): void
@@ -112,18 +101,14 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertFalse($csrfToken->validate(Random::string()));
         $this->assertFalse($csrfToken->validate('*'));
 
-        $token = StringHelper::base64UrlEncode(
-            (new Mac('sha256'))->sign('a2~user1', 'mySecretKey', true),
-        );
+        $token = $this->createToken('user7', 'a2');
         $this->assertFalse($csrfToken->validate($token));
 
-        $token = StringHelper::base64UrlEncode(
-            (new Mac('sha256'))->sign('hello', 'mySecretKey', true),
-        );
+        $token = $this->createToken('user7', 'hello');
         $this->assertFalse($csrfToken->validate($token));
     }
 
-    public function testValidatesTokenSignedWithCurrentIdentityAndMessage(): void
+    public function testValidatesTokenSignedWithCurrentIdentity(): void
     {
         self::$timeResult = 300;
 
@@ -132,7 +117,7 @@ final class HmacCsrfTokenTest extends TestCase
             'mySecretKey',
         );
 
-        $this->assertTrue($csrfToken->validate($this->createToken('user7', '500~random-value-with~delimiter')));
+        $this->assertTrue($csrfToken->validate($this->createToken('user7', '500')));
     }
 
     public function testRejectsSignedTokenWithMalformedMessage(): void
@@ -144,9 +129,9 @@ final class HmacCsrfTokenTest extends TestCase
             'mySecretKey',
         );
 
-        $this->assertFalse($csrfToken->validate($this->createToken('user7', '500')));
-        $this->assertFalse($csrfToken->validate($this->createToken('user7', '0500~random-value')));
-        $this->assertFalse($csrfToken->validate($this->createToken('user7', 'not-a-timestamp~random-value')));
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', '0500')));
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', 'not-a-timestamp')));
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', '500~extra')));
     }
 
     public function testInvalidTokenParsingDoesNotGenerateIdentity(): void
@@ -181,7 +166,7 @@ final class HmacCsrfTokenTest extends TestCase
         };
         $csrfToken = new HmacCsrfToken($identityGenerator, 'mySecretKey');
 
-        $this->assertFalse($csrfToken->validate($this->createToken('user7', '299~random-value')));
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', '299')));
         $this->assertSame(0, $identityGenerator->calls);
     }
 
@@ -200,8 +185,12 @@ final class HmacCsrfTokenTest extends TestCase
     private function createToken(string $identity, string $message): string
     {
         $signedMessage = StringHelper::byteLength($identity) . '~' . $identity . '~' . $message;
+        $hash = hash_hmac('sha256', $signedMessage, 'mySecretKey', true);
+        if (!$hash) {
+            self::fail('Failed to generate HMAC.');
+        }
 
-        return StringHelper::base64UrlEncode(hash_hmac('sha256', $signedMessage, 'mySecretKey', true) . $message);
+        return StringHelper::base64UrlEncode($hash . $message);
     }
 
     private function getHashLength(): int

--- a/tests/Hmac/HmacCsrfTokenTest.php
+++ b/tests/Hmac/HmacCsrfTokenTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Csrf\Tests\Hmac;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Csrf\Hmac\HmacCsrfToken;
+use Yiisoft\Csrf\Hmac\IdentityGenerator\CsrfTokenIdentityGeneratorInterface;
 use Yiisoft\Csrf\Tests\Hmac\IdentityGenerator\MockCsrfTokenIdentityGenerator;
 use Yiisoft\Security\Mac;
 use Yiisoft\Security\Random;
@@ -92,6 +93,7 @@ final class HmacCsrfTokenTest extends TestCase
         );
 
         $this->assertFalse($csrfToken->validate(Random::string()));
+        $this->assertFalse($csrfToken->validate('*'));
 
         $token = StringHelper::base64UrlEncode(
             (new Mac('sha256'))->sign('a2~user1', 'mySecretKey', true),
@@ -102,6 +104,23 @@ final class HmacCsrfTokenTest extends TestCase
             (new Mac('sha256'))->sign('hello', 'mySecretKey', true),
         );
         $this->assertFalse($csrfToken->validate($token));
+    }
+
+    public function testInvalidTokenParsingDoesNotGenerateIdentity(): void
+    {
+        $identityGenerator = new class implements CsrfTokenIdentityGeneratorInterface {
+            public int $calls = 0;
+
+            public function generate(): string
+            {
+                $this->calls++;
+                return 'user7';
+            }
+        };
+        $csrfToken = new HmacCsrfToken($identityGenerator, 'mySecretKey');
+
+        $this->assertFalse($csrfToken->validate(StringHelper::base64UrlEncode('short')));
+        $this->assertSame(0, $identityGenerator->calls);
     }
 
     public function testIdentityWithTilda(): void

--- a/tests/Hmac/HmacCsrfTokenTest.php
+++ b/tests/Hmac/HmacCsrfTokenTest.php
@@ -38,6 +38,30 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertTrue($csrfToken->validate($token));
     }
 
+    public function testTokenValueChanges(): void
+    {
+        $csrfToken = new HmacCsrfToken(
+            new MockCsrfTokenIdentityGenerator('user7'),
+            'mySecretKey',
+        );
+
+        $this->assertNotSame($csrfToken->getValue(), $csrfToken->getValue());
+    }
+
+    public function testTokenDoesNotExposeIdentity(): void
+    {
+        $identity = 'session-id-that-must-not-be-in-token';
+        $csrfToken = new HmacCsrfToken(
+            new MockCsrfTokenIdentityGenerator($identity),
+            'mySecretKey',
+        );
+
+        $token = $csrfToken->getValue();
+
+        $this->assertStringNotContainsString($identity, StringHelper::base64UrlDecode($token));
+        $this->assertTrue($csrfToken->validate($token));
+    }
+
     public function testExpiration(): void
     {
         self::$timeResult = 300;

--- a/tests/Hmac/HmacCsrfTokenTest.php
+++ b/tests/Hmac/HmacCsrfTokenTest.php
@@ -63,6 +63,23 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertTrue($csrfToken->validate($token));
     }
 
+    public function testTokenPayloadContainsExpirationAndRandomValue(): void
+    {
+        self::$timeResult = 300;
+
+        $csrfToken = new HmacCsrfToken(
+            new MockCsrfTokenIdentityGenerator('user7'),
+            'mySecretKey',
+            'sha256',
+            100,
+        );
+
+        $payload = StringHelper::base64UrlDecode($csrfToken->getValue());
+        $message = StringHelper::byteSubstring($payload, $this->getHashLength(), null);
+
+        $this->assertMatchesRegularExpression('/^400~[A-Za-z0-9_-]{32}$/', $message);
+    }
+
     public function testExpiration(): void
     {
         self::$timeResult = 300;
@@ -106,6 +123,32 @@ final class HmacCsrfTokenTest extends TestCase
         $this->assertFalse($csrfToken->validate($token));
     }
 
+    public function testValidatesTokenSignedWithCurrentIdentityAndMessage(): void
+    {
+        self::$timeResult = 300;
+
+        $csrfToken = new HmacCsrfToken(
+            new MockCsrfTokenIdentityGenerator('user7'),
+            'mySecretKey',
+        );
+
+        $this->assertTrue($csrfToken->validate($this->createToken('user7', '500~random-value-with~delimiter')));
+    }
+
+    public function testRejectsSignedTokenWithMalformedMessage(): void
+    {
+        self::$timeResult = 300;
+
+        $csrfToken = new HmacCsrfToken(
+            new MockCsrfTokenIdentityGenerator('user7'),
+            'mySecretKey',
+        );
+
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', '500')));
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', '0500~random-value')));
+        $this->assertFalse($csrfToken->validate($this->createToken('user7', 'not-a-timestamp~random-value')));
+    }
+
     public function testInvalidTokenParsingDoesNotGenerateIdentity(): void
     {
         $identityGenerator = new class implements CsrfTokenIdentityGeneratorInterface {
@@ -133,6 +176,18 @@ final class HmacCsrfTokenTest extends TestCase
         $token = $csrfToken->getValue();
 
         $this->assertTrue($csrfToken->validate($token));
+    }
+
+    private function createToken(string $identity, string $message): string
+    {
+        $signedMessage = StringHelper::byteLength($identity) . '~' . $identity . '~' . $message;
+
+        return StringHelper::base64UrlEncode(hash_hmac('sha256', $signedMessage, 'mySecretKey', true) . $message);
+    }
+
+    private function getHashLength(): int
+    {
+        return StringHelper::byteLength(hash_hmac('sha256', '', '', true));
     }
 }
 


### PR DESCRIPTION
- change HMAC CSRF tokens so the emitted payload contains expiration only, while the HMAC remains bound to the current identity
- stop exposing the default session identity in decoded token payloads
- update OWASP CSRF cheat sheet terminology/link and clarify HMAC token replay semantics

Fixes #32.